### PR TITLE
Add terraform

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,27 @@
+name: Pull Requests
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - '*.md'
+      - '*.yaml'
+    branches:
+      - main
+
+jobs:
+  terraform-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Render terraform docs and push changes back to PR
+      uses: terraform-docs/gh-actions@main
+      with:
+        working-dir: terraform/dev/rob-cos,terraform/modules/microceph,terraform/modules/rob-cos-overlay
+        output-file: README.md
+        output-method: inject
+        git-push: "true"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,35 @@
 # rob-cos-overlay
 
-The rob-cos overlay is an overlay bundle for [cos-lite](https://github.com/canonical/cos-lite-bundle/tree/main).
+The rob-cos overlay is an overlay bundle for [cos-lite](https://github.com/canonical/cos-lite-bundle).
 The robotics overlay customises the upstream COS lite bundle to observe robotics devices.
+
+## Use
+
+### Terraform
+
+This repository contains a collection of Terraform configurations to ease the deployment of COS for devices.
+Most notably it contains:
+
+- a Terraform module for deploying [microceph](./terraform/modules/microceph/README.md)
+- a Terraform module for deploying the [rob-cos](./terraform/modules/rob-cos-overlay/README.md) overlay
+- a demonstration Terraform module for deploying a fully working [rob-cos](./terraform/dev/rob-cos/README.md) project
+
+### Juju bundle
+
+> [!WARNING]
+> Juju bundles are being deprecated.
+> Please use [Terraform](#terraform) instead.
 
 To deploy the rob-cos bundle follow these instructions:
 
 Clone the source repository:
 
-```
+```bash
 git clone https://github.com/ubuntu-robotics/rob-cos-overlay.git
 ```
 
 Deploy as follows:
 
-```
+```bash
 juju deploy cos-lite --trust --overlay ./robotics-overlay.yaml
 ```

--- a/terraform/dev/rob-cos/.terraform-docs.yml
+++ b/terraform/dev/rob-cos/.terraform-docs.yml
@@ -1,0 +1,48 @@
+formatter: "markdown"
+
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: modules
+  include-main: true
+
+sections:
+  hide: []
+  show: []
+
+content: ""
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  anchor: false #true
+  # color: true
+  default: true
+  # description: false
+  escape: true
+  hide-empty: true
+  html: false #true
+  indent: 2
+  lockfile: false
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform/dev/rob-cos/README.md
+++ b/terraform/dev/rob-cos/README.md
@@ -1,0 +1,28 @@
+# Terraform module for `rob-cos`
+
+This is a Terraform module facilitating the deployment of the COS for Devices project,
+using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/).
+For more information,
+refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+> [!CAUTION]
+> This module is not intended to be deployed in production.
+> It rather is a demonstrator as well as a starting point for developing a production-grade configuration.
+
+## Requirements
+
+This module requires both a Juju machine model as well as a Juju k8s model to be available.
+Refer to the [usage section](#usage) below for more details.
+
+## Usage
+
+Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
+
+To deploy this module with its needed dependency, you can run:
+
+```bash
+terraform apply -var="robcos_model=<K8S_MODEL_NAME>" -var="microceph_model=<MACHINE_MODEL_NAME>"
+```
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/terraform/dev/rob-cos/main.tf
+++ b/terraform/dev/rob-cos/main.tf
@@ -1,0 +1,296 @@
+# -------------- # Models --------------
+
+data "juju_model" "robcos_model" {
+  name = var.robcos_model
+}
+
+data "juju_model" "microceph_model" {
+  name = var.microceph_model
+}
+
+# -------------- # Applications --------------
+
+module "cos_lite" {
+  source     = "git::https://github.com/canonical/observability//terraform/modules/cos-lite"
+  model_name = data.juju_model.robcos_model.name
+  channel    = var.cos_lite.channel
+  use_tls    = var.cos_lite.use_tls
+}
+
+module "robcos_overlay" {
+  source = "../../modules/robcos_overlay"
+  model  = data.juju_model.robcos_model.name
+  cos_registration_server = var.cos_registration_server
+  foxglove_studio = var.foxglove_studio
+}
+
+module "microceph" {
+  source   = "../../modules/microceph"
+  app_name = "microceph"
+  model    = data.juju_model.microceph_model.name
+  channel  = var.microceph.channel
+  units    = var.microceph.units
+  config   = { "enable-rgw" = "*" }
+}
+
+# -------------- # Offers --------------
+
+resource "juju_offer" "microceph" {
+  model            = data.juju_model.microceph_model.name
+  application_name = module.microceph.app_name
+  endpoint         = module.microceph.requires.traefik_route_rgw
+}
+
+# -------------- # Integrations --------------
+
+# Provided by Catalogue
+
+resource "juju_integration" "catalogue_cos_registration_server" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.catalogue
+    endpoint = "catalogue"
+  }
+
+  application {
+    name     = module.robcos_overlay.cos_registration_server.app_name
+    endpoint = module.robcos_overlay.cos_registration_server.requires.catalogue
+  }
+}
+
+resource "juju_integration" "catalogue_foxglove_studio" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.catalogue
+    endpoint = "catalogue"
+  }
+
+  application {
+    name     = module.robcos_overlay.foxglove_studio.app_name
+    endpoint = module.robcos_overlay.foxglove_studio.requires.catalogue
+  }
+}
+
+# Provided by COS registration server
+
+resource "juju_integration" "grafana_dashboard_cos_registration_server" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.robcos_overlay.cos_registration_server.app_name
+    endpoint = module.robcos_overlay.cos_registration_server.provides.grafana_dashboard
+  }
+
+  application {
+    name     = module.cos_lite.app_names.grafana_agent
+    endpoint = "grafana-dashboards-consumer"
+  }
+}
+
+resource "juju_integration" "grafana_dashboard_devices_cos_registration_server" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.robcos_overlay.cos_registration_server.app_name
+    endpoint = module.robcos_overlay.cos_registration_server.provides.grafana_dashboard_devices
+  }
+
+  application {
+    name     = module.cos_lite.app_names.grafana
+    endpoint = module.cos_lite.grafana.endpoints.grafana_dashboard
+  }
+}
+
+# resource "juju_integration" "probes_cos_registration_server" {
+#   model = data.juju_model.robcos_model.name
+
+#   application {
+#     name     = module.robcos_overlay.cos_registration_server.app_name
+#     endpoint = module.robcos_overlay.cos_registration_server.provides.probes
+#   }
+
+#   application {
+#     name     = module.cos_lite.app_names.blackbox
+#     endpoint = "probes"
+#   }
+# }
+
+# resource "juju_integration" "probes_devices_cos_registration_server" {
+#   model = data.juju_model.robcos_model.name
+
+#   application {
+#     name     = module.robcos_overlay.cos_registration_server.app_name
+#     endpoint = module.robcos_overlay.cos_registration_server.provides.probes_devices
+#   }
+
+#   application {
+#     name     = module.cos_lite.app_names.blackbox
+#     endpoint = "probes"
+#   }
+# }
+
+# Provided by Foxglove Studio
+
+resource "juju_integration" "grafana_dashboard_foxglove_studio" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.robcos_overlay.foxglove_studio.app_name
+    endpoint = module.robcos_overlay.foxglove_studio.provides.grafana_dashboard
+  }
+
+  application {
+    name     = module.cos_lite.app_names.grafana_agent
+    endpoint = "grafana-dashboards-consumer"
+  }
+}
+
+# resource "juju_integration" "probes_foxglove_studio" {
+#   model = data.juju_model.robcos_model.name
+
+#   application {
+#     name     = module.robcos_overlay.foxglove_studio.app_name
+#     endpoint = module.robcos_overlay.foxglove_studio.provides.probes
+#   }
+
+#   application {
+#     name     = module.cos_lite.app_names.blackbox
+#     endpoint = "probes"
+#   }
+# }
+
+# Provided by Loki
+
+resource "juju_integration" "logging_alert_devices_cos_registration_server" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.loki
+    endpoint = module.cos_lite.loki.endpoints.logging #"logging"
+  }
+
+  application {
+    name     = module.robcos_overlay.cos_registration_server.app_name
+    endpoint = module.robcos_overlay.cos_registration_server.requires.logging_alerts_devices
+  }
+}
+
+# Provided by Grafana Agent
+
+resource "juju_integration" "logging_cos_registration_server" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.grafana_agent
+    endpoint = "logging-provider"
+  }
+
+  application {
+    name     = module.robcos_overlay.cos_registration_server.app_name
+    endpoint = module.robcos_overlay.cos_registration_server.requires.logging
+  }
+}
+
+resource "juju_integration" "tracing_cos_registration_server" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.grafana_agent
+    endpoint = "tracing-provider"
+  }
+
+  application {
+    name     = module.robcos_overlay.cos_registration_server.app_name
+    endpoint = module.robcos_overlay.cos_registration_server.requires.tracing
+  }
+}
+
+resource "juju_integration" "logging_foxglove_studio" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.grafana_agent
+    endpoint = "logging-provider"
+  }
+
+  application {
+    name     = module.robcos_overlay.foxglove_studio.app_name
+    endpoint = module.robcos_overlay.foxglove_studio.requires.logging
+  }
+}
+
+resource "juju_integration" "tracing_foxglove_studio" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.grafana_agent
+    endpoint = "tracing-provider"
+  }
+
+  application {
+    name     = module.robcos_overlay.foxglove_studio.app_name
+    endpoint = module.robcos_overlay.foxglove_studio.requires.tracing
+  }
+}
+
+# Provided by Prometheus
+
+resource "juju_integration" "send_remote_write_alerts_devices_cos_registration_server" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.prometheus
+    endpoint = module.cos_lite.prometheus.endpoints.receive_remote_write
+    # endpoint = "receive_remote_write"
+  }
+
+  application {
+    name     = module.robcos_overlay.cos_registration_server.app_name
+    endpoint = module.robcos_overlay.cos_registration_server.requires.send_remote_write_alerts_devices
+  }
+}
+
+# Provided by Traefik
+
+resource "juju_integration" "ingress_cos_registration_server" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.traefik
+    endpoint = "traefik-route"
+  }
+
+  application {
+    name     = module.robcos_overlay.cos_registration_server.app_name
+    endpoint = module.robcos_overlay.cos_registration_server.requires.ingress
+  }
+}
+
+resource "juju_integration" "ingress_foxglove_studio" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.traefik
+    endpoint = "traefik-route"
+  }
+
+  application {
+    name     = module.robcos_overlay.foxglove_studio.app_name
+    endpoint = module.robcos_overlay.foxglove_studio.requires.ingress
+  }
+}
+
+resource "juju_integration" "ingress_microceph" {
+  model = data.juju_model.robcos_model.name
+
+  application {
+    name     = module.cos_lite.app_names.traefik
+    endpoint = "traefik-route"
+  }
+
+  application {
+    offer_url = juju_offer.microceph.url
+  }
+}

--- a/terraform/dev/rob-cos/outputs.tf
+++ b/terraform/dev/rob-cos/outputs.tf
@@ -1,0 +1,24 @@
+output "app_names" {
+  value = merge(
+    {
+      cos_registratio_server = module.cos_registration_server.app_name,
+      foxglove_studio        = module.foxglove_studio.app_name,
+    }
+  )
+  description = "The names of the deployed applications"
+}
+
+output "cos_lite" {
+  description = "Outputs from the COS lite module"
+  value       = module.cos_lite
+}
+
+output "robcos_overlay" {
+  description = "Outputs from the robcos-overlay module"
+  value       = module.robcos_overlay
+}
+
+output "microceph" {
+  description = "Outputs from the microceph module"
+  value       = module.microceph
+}

--- a/terraform/dev/rob-cos/variables.tf
+++ b/terraform/dev/rob-cos/variables.tf
@@ -1,0 +1,58 @@
+variable "robcos_model" {
+  description = "Model name (must be a k8s model)"
+  type        = string
+}
+
+variable "microceph_model" {
+  description = "Model name (must be a machine model)"
+  type        = string
+}
+
+variable "cos_lite" {
+  type = object({
+    channel = optional(string, "latest/edge")
+    use_tls = optional(bool, false)
+  })
+  default = {}
+  description = <<-EOT
+  The cos-lite variables.
+  Please refer to the module for more information.
+  EOT
+}
+
+variable "cos_registration_server" {
+  type = object({
+    channel  = optional(string, "latest/edge")
+    revision = optional(number, null)
+  })
+  default = {}
+  description = <<-EOT
+  The cos-registration-server variables.
+  Please refer to the module for more information.
+  EOT
+}
+
+variable "foxglove_studio" {
+  type = object({
+    channel  = optional(string, "latest/edge")
+    revision = optional(number, null)
+  })
+  default = {}
+  description = <<-EOT
+  The foxglove-studio variables.
+  Please refer to the module for more information.
+  EOT
+}
+
+variable "microceph" {
+  type = object({
+    channel  = optional(string, "squid/stable")
+    revision = optional(number, null)
+    units    = optional(number, 3)
+  })
+  default = {}
+  description = <<-EOT
+  The microceph variables.
+  Please refer to the module for more information.
+  EOT
+}

--- a/terraform/dev/rob-cos/versions.tf
+++ b/terraform/dev/rob-cos/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.19.0"
+    }
+  }
+}

--- a/terraform/modules/microceph/.terraform-docs.yml
+++ b/terraform/modules/microceph/.terraform-docs.yml
@@ -1,0 +1,48 @@
+formatter: "markdown"
+
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: modules
+  include-main: true
+
+sections:
+  hide: []
+  show: []
+
+content: ""
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  anchor: false #true
+  # color: true
+  default: true
+  # description: false
+  escape: true
+  hide-empty: true
+  html: false #true
+  indent: 2
+  lockfile: false
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform/modules/microceph/README.md
+++ b/terraform/modules/microceph/README.md
@@ -1,0 +1,26 @@
+# Terraform module for `microceph`
+
+This is a Terraform module facilitating the deployment of the `microceph` charm,
+using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/).
+For more information,
+refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+> Note: This module temporarily lives here until the microceph charm provides its own.
+
+## Requirements
+
+This module requires a Juju machine model to be available.
+Refer to the [usage section](#usage) below for more details.
+
+## Usage
+
+Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
+
+To deploy this module with its needed dependency, you can run:
+
+```bash
+terraform apply -var="model=<MODEL_NAME>"
+```
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/terraform/modules/microceph/main.tf
+++ b/terraform/modules/microceph/main.tf
@@ -1,0 +1,22 @@
+# -------------- # Model --------------
+
+data "juju_model" "model" {
+  name = var.model
+}
+
+# -------------- # Application --------------
+
+resource "juju_application" "microceph" {
+  name  = var.app_name
+  model = data.juju_model.model.name
+  # We always need this variable to be true in order
+  # to be able to apply resources limits.
+  trust = true
+  charm {
+    name     = "microceph"
+    channel  = var.channel
+    revision = var.revision
+  }
+  units  = var.units
+  config = var.config
+}

--- a/terraform/modules/microceph/outputs.tf
+++ b/terraform/modules/microceph/outputs.tf
@@ -1,0 +1,23 @@
+output "app_name" {
+  value = juju_application.microceph.name
+  description = "The name of the deployed application"
+}
+
+output "requires" {
+  value = {
+    traefik_route_rgw = "traefik-route-rgw"
+    identity_service  = "identity-service"
+    receive_ca_cert   = "receive-ca-cert"
+  }
+  description = "The integration endpoints required by the application"
+}
+
+output "provides" {
+  value = {
+    ceph      = "ceph"
+    radosgw   = "radosgw"
+    mds       = "mds"
+    cos_agent = "cos-agent"
+  }
+  description = "The integration endpoints provided by the application"
+}

--- a/terraform/modules/microceph/variables.tf
+++ b/terraform/modules/microceph/variables.tf
@@ -1,0 +1,43 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "microceph"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = "squid/stable"
+}
+
+variable "config" {
+  description = "Config options as in the ones we pass in juju config"
+  type        = map(string)
+  default     = {}
+}
+
+# We use constraints to set AntiAffinity in K8s
+# https://discourse.charmhub.io/t/pod-priority-and-affinity-in-juju-charms/4091/13?u=jose
+variable "constraints" {
+  description = "Constraints to be applied"
+  type        = string
+  default     = ""
+}
+
+variable "model" {
+  description = "Model name (must be a machine model)"
+  type        = string
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  nullable    = true
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units"
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/microceph/versions.tf
+++ b/terraform/modules/microceph/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.19.0"
+    }
+  }
+}

--- a/terraform/modules/rob-cos-overlay/.terraform-docs.yml
+++ b/terraform/modules/rob-cos-overlay/.terraform-docs.yml
@@ -1,0 +1,48 @@
+formatter: "markdown"
+
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: modules
+  include-main: true
+
+sections:
+  hide: []
+  show: []
+
+content: ""
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  anchor: false #true
+  # color: true
+  default: true
+  # description: false
+  escape: true
+  hide-empty: true
+  html: false #true
+  indent: 2
+  lockfile: false
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform/modules/rob-cos-overlay/README.md
+++ b/terraform/modules/rob-cos-overlay/README.md
@@ -1,0 +1,25 @@
+# Terraform module for the COS for devices overlay
+
+This is a Terraform module facilitating the deployment of the COS for devices charms
+on top of [COS-lite](https://github.com/canonical/observability/blob/main/terraform/modules/cos-lite),
+using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/).
+For more information,
+refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+## Requirements
+
+This module requires a Juju k8s model to be available.
+Refer to the [usage section](#usage) below for more details.
+
+## Usage
+
+Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
+
+To deploy this module with its needed dependency, you can run:
+
+```bash
+terraform apply -var="model=<MODEL_NAME>"
+```
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/terraform/modules/rob-cos-overlay/main.tf
+++ b/terraform/modules/rob-cos-overlay/main.tf
@@ -1,0 +1,23 @@
+# -------------- # Model --------------
+
+data "juju_model" "model" {
+  name = var.model
+}
+
+# -------------- # Applications --------------
+
+module "cos_registration_server" {
+  source   = "git::https://github.com/canonical/cos-registration-server-k8s-operator//terraform"
+  app_name = "cos-registration-server"
+  model    = data.juju_model.model.name
+  channel  = var.cos_registration_server.channel
+  revision = var.cos_registration_server.revision
+}
+
+module "foxglove_studio" {
+  source   = "git::https://github.com/ubuntu-robotics/foxglove-k8s-operator//terraform"
+  app_name = "foxglove-studio"
+  model    = data.juju_model.model.name
+  channel  = var.foxglove_studio.channel
+  revision = var.foxglove_studio.revision
+}

--- a/terraform/modules/rob-cos-overlay/outputs.tf
+++ b/terraform/modules/rob-cos-overlay/outputs.tf
@@ -1,0 +1,19 @@
+output "app_names" {
+  value = merge(
+    {
+      cos_registratio_server = module.cos_registration_server.app_name,
+      foxglove_studio        = module.foxglove_studio.app_name,
+    }
+  )
+  description = "The names of the deployed applications"
+}
+
+output "cos_registration_server" {
+  description = "Outputs from the COS registration server module"
+  value       = module.cos_registration_server
+}
+
+output "foxglove_studio" {
+  description = "Outputs from the Foxglove Studio module"
+  value       = module.foxglove_studio
+}

--- a/terraform/modules/rob-cos-overlay/variables.tf
+++ b/terraform/modules/rob-cos-overlay/variables.tf
@@ -1,0 +1,28 @@
+variable "model" {
+  description = "Model name (must be a k8s model)"
+  type        = string
+}
+
+variable "cos_registration_server" {
+  type = object({
+    channel  = optional(string, "latest/edge")
+    revision = optional(number, null)
+  })
+  default     = {}
+  description = <<-EOT
+  The cos-registration-server variables.
+  Please refer to the module for more information.
+  EOT
+}
+
+variable "foxglove_studio" {
+  type = object({
+    channel  = optional(string, "latest/edge")
+    revision = optional(number, null)
+  })
+  default     = {}
+  description = <<-EOT
+  The foxglove-studio variables.
+  Please refer to the module for more information.
+  EOT
+}

--- a/terraform/modules/rob-cos-overlay/versions.tf
+++ b/terraform/modules/rob-cos-overlay/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.19.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds Terraform configurations for:

- microceph charm - temporary until the project ships its own
- rob-cos-overlay - somewhat mimics the deprecated overlay. It does not deploy the rosbag storage which will be replaced by microceph. It also does not handle the relations as it is unclear how to do so in a modular fashion at the moment.
- rob-cos - a plan to deploy the full stack - cos-lite + rob-cos-overlay + microceph - fully working (or almost *).

* 'almost' because some juju actions are still required to be ran and this is not handled by the juju terraform provider.