### PR TITLE
Fix bundle relations

### DIFF
--- a/robotics-overlay.yaml
+++ b/robotics-overlay.yaml
@@ -34,12 +34,12 @@ applications:
       database: 1G
 
 relations:
-  - [foxglove-studio:ingress, traefik:traefik-route]
+  - [foxglove-studio:ingress, traefik:ingress]
   - [foxglove-studio:catalogue, catalogue:catalogue]
   - [ros2bag-fileserver:ingress-tcp, traefik:ingress-per-unit]
   - [ros2bag-fileserver:ingress-http, traefik:ingress]
   - [ros2bag-fileserver:catalogue, catalogue:catalogue]
-  - [cos-registration-server:ingress, traefik:traefik-route]
+  - [cos-registration-server:ingress, traefik:ingress]
   - [cos-registration-server:catalogue, catalogue:catalogue]
   - [cos-registration-server:auth-devices-keys,  ros2bag-fileserver:auth-devices-keys]
   - [grafana:grafana-dashboard, cos-registration-server:grafana-dashboard]


### PR DESCRIPTION
Fix bundle relations for foxglove and cos-registration with traefik, since they have been changed in latest revisions:
https://github.com/canonical/cos-registration-server-k8s-operator/pull/38 and https://github.com/ubuntu-robotics/foxglove-k8s-operator/pull/19