### PR TITLE
Fix juju provider 0.20.0 change

### DIFF
--- a/terraform/microceph/README.md
+++ b/terraform/microceph/README.md
@@ -27,13 +27,13 @@ terraform apply -var="model=<MODEL_NAME>"
 | Name | Version |
 |------|---------|
 | terraform | >= 1.5 |
-| juju | ~> 0.19.0 |
+| juju | >= 0.14.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| juju | ~> 0.19.0 |
+| juju | >= 0.14.0 |
 
 ## Resources
 

--- a/terraform/microceph/versions.tf
+++ b/terraform/microceph/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.19.0"
+      version = ">= 0.14.0"
     }
   }
 }

--- a/terraform/rob-cos-microceph/README.md
+++ b/terraform/rob-cos-microceph/README.md
@@ -44,14 +44,14 @@ We can then destroy the deployment as usual with `terraform destroy`.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.5 |
-| juju | ~> 0.19.0 |
+| juju | >= 0.20.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| juju.microceph | ~> 0.19.0 |
-| juju.robcos | ~> 0.19.0 |
+| juju.microceph | >= 0.20.0 |
+| juju.robcos | >= 0.20.0 |
 
 ## Modules
 

--- a/terraform/rob-cos-microceph/main.tf
+++ b/terraform/rob-cos-microceph/main.tf
@@ -59,7 +59,7 @@ module "microceph" {
 resource "juju_offer" "microceph" {
   model            = data.juju_model.microceph_model.name
   application_name = module.microceph.app_name
-  endpoint         = module.microceph.requires.traefik_route_rgw
+  endpoints        = [module.microceph.requires.traefik_route_rgw]
 
   provider = juju.microceph
 }

--- a/terraform/rob-cos-microceph/versions.tf
+++ b/terraform/rob-cos-microceph/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.19.0"
+      version = ">= 0.20.0"
     }
   }
 }

--- a/terraform/rob-cos/README.md
+++ b/terraform/rob-cos/README.md
@@ -25,13 +25,13 @@ terraform apply -var="model=<K8S_MODEL_NAME>"
 | Name | Version |
 |------|---------|
 | terraform | >= 1.5 |
-| juju | ~> 0.19.0 |
+| juju | >= 0.14.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| juju | ~> 0.19.0 |
+| juju | >= 0.14.0 |
 
 ## Modules
 

--- a/terraform/rob-cos/versions.tf
+++ b/terraform/rob-cos/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.19.0"
+      version = ">= 0.14.0"
     }
   }
 }


### PR DESCRIPTION
Relax the Juju provider version constraint in some modules and update to Juju provider 0.20.0 where applicable to fix a breaking a change (see https://github.com/juju/terraform-provider-juju/releases/tag/v0.20.0).