### PR TITLE
Update Juju provider version constraint

### DIFF
--- a/terraform/microceph/README.md
+++ b/terraform/microceph/README.md
@@ -27,13 +27,13 @@ terraform apply -var="model=<MODEL_NAME>"
 | Name | Version |
 |------|---------|
 | terraform | >= 1.5 |
-| juju | >= 0.14.0 |
+| juju | >= 0.14.0, < 1.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| juju | >= 0.14.0 |
+| juju | >= 0.14.0, < 1.0.0 |
 
 ## Resources
 

--- a/terraform/microceph/versions.tf
+++ b/terraform/microceph/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }

--- a/terraform/rob-cos-microceph/README.md
+++ b/terraform/rob-cos-microceph/README.md
@@ -44,14 +44,14 @@ We can then destroy the deployment as usual with `terraform destroy`.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.5 |
-| juju | >= 0.20.0 |
+| juju | >= 0.20.0, < 1.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| juju.microceph | >= 0.20.0 |
-| juju.robcos | >= 0.20.0 |
+| juju.microceph | >= 0.20.0, < 1.0.0 |
+| juju.robcos | >= 0.20.0, < 1.0.0 |
 
 ## Modules
 

--- a/terraform/rob-cos-microceph/versions.tf
+++ b/terraform/rob-cos-microceph/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20.0"
+      version = ">= 0.20.0, < 1.0.0"
     }
   }
 }

--- a/terraform/rob-cos/README.md
+++ b/terraform/rob-cos/README.md
@@ -25,13 +25,13 @@ terraform apply -var="model=<K8S_MODEL_NAME>"
 | Name | Version |
 |------|---------|
 | terraform | >= 1.5 |
-| juju | >= 0.14.0 |
+| juju | >= 0.14.0, < 1.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| juju | >= 0.14.0 |
+| juju | >= 0.14.0, < 1.0.0 |
 
 ## Modules
 

--- a/terraform/rob-cos/versions.tf
+++ b/terraform/rob-cos/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
The latest Juju provider ([v1.0.0](https://registry.terraform.io/providers/juju/juju/1.0.0/docs/resources/application)) introduced a breaking change in the `juju_application resource`, the `model` field was replaced with `model_uuid`.

This PR updates the provider version constraint and adjusts the Terraform plan accordingly to ensure compatibility with the new schema.

This issue also affects cos-lite. An issue has been opened https://github.com/canonical/observability-stack/issues/130.
