### PR TITLE
Test/terraform

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -25,11 +25,84 @@ jobs:
         output-file: README.md
         output-method: inject
         git-push: "true"
-  terraform-lint:
+
+  terraform-validate:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-    - name: Lint Terraform
-      uses: actionshub/terraform-lint@main
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y tox
+        sudo snap install terraform --classic
+
+    - name: Validate Terraform
+      run: |
+        tox -e terraform-validate
+
+  terraform-test:
+    needs: terraform-validate
+    runs-on: self-hosted-linux-amd64-noble-xlarge
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y tox
+        sudo snap install terraform --classic
+        sudo snap install concierge --classic
+        sudo snap install lxd
+        sudo concierge prepare --preset microk8s
+
+    - name: Prepare juju tf provider environment
+      run: |
+        CONTROLLER=$(juju whoami | yq .Controller)
+        JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq '.[$CONTROLLER]'.details.\"api-endpoints\" | tr -d "[]' "|tr -d '"'|tr -d '\n')"
+        JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user|tr -d '"')"
+        JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password|tr -d '"')"
+
+        echo "JUJU_CONTROLLER_ADDRESSES=$JUJU_CONTROLLER_ADDRESSES" >> "$GITHUB_ENV"
+        echo "JUJU_USERNAME=$JUJU_USERNAME" >> "$GITHUB_ENV"
+        echo "JUJU_PASSWORD=$JUJU_PASSWORD" >> "$GITHUB_ENV"
+        {
+          echo 'JUJU_CA_CERT<<EOF'
+          juju show-controller $(echo $CONTROLLER|tr -d '"') | yq '.[$CONTROLLER]'.details.\"ca-cert\"|tr -d '"'
+          echo EOF
+        } >> "$GITHUB_ENV"
+
+    - name: Setup LXD cloud for Ceph
+      run: |
+        set -x
+        lxd init --minimal
+        lxc config set core.https_address :8443
+        HOST_IP_ADDRESS=$(hostname -I | awk '{print $1}')
+        cat <<EOF > lxd-cloud.yaml
+        clouds:
+          lxd-local:
+            type: lxd
+            auth-types: [certificate]
+            endpoint: https://${HOST_IP_ADDRESS}
+            regions:
+              default:
+                endpoint: https://${HOST_IP_ADDRESS}
+        EOF
+
+        juju add-cloud --client --controller concierge-microk8s --file lxd-cloud.yaml
+
+        # Done this way to avoid the interactive prompt
+        # Doing it via juju add-credentials requires generating certificates, concatinating them etc.
+        printf "1\nlxd-local\nQ\n" | juju autoload-credentials --client --controller concierge-microk8s lxd
+
+        # Logging the clouds
+        juju clouds --client --controller concierge-microk8s
+
+        juju add-model testing-lxd lxd-local
+
+        # log the models
+        juju models
+
+    - name: Test Terraform
+      run: |
+        tox -e terraform-test

--- a/terraform/microceph/tests/main.tf
+++ b/terraform/microceph/tests/main.tf
@@ -1,0 +1,20 @@
+data "juju_model" "model" {
+  name  = "testing-lxd"
+  owner = "admin"
+}
+
+terraform {
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+module "microceph" {
+  model_uuid = data.juju_model.model.uuid
+  source     = "./.."
+}

--- a/terraform/microceph/tests/main.tftest.hcl
+++ b/terraform/microceph/tests/main.tftest.hcl
@@ -1,0 +1,43 @@
+run "basic_deploy" {
+  command = apply
+
+  assert {
+    condition     = module.microceph.app_name != ""
+    error_message = "microceph app_name should be set"
+  }
+
+  assert {
+    condition     = module.microceph.requires.traefik_route_rgw == "traefik-route-rgw"
+    error_message = "requires should expose traefik-route-rgw"
+  }
+
+  assert {
+    condition     = module.microceph.requires.identity_service == "identity-service"
+    error_message = "requires should expose identity-service"
+  }
+
+  assert {
+    condition     = module.microceph.requires.receive_ca_cert == "receive-ca-cert"
+    error_message = "requires should expose receive-ca-cert"
+  }
+
+  assert {
+    condition     = module.microceph.provides.ceph == "ceph"
+    error_message = "provides should expose ceph"
+  }
+
+  assert {
+    condition     = module.microceph.provides.radosgw == "radosgw"
+    error_message = "provides should expose radosgw"
+  }
+
+  assert {
+    condition     = module.microceph.provides.mds == "mds"
+    error_message = "provides should expose mds"
+  }
+
+  assert {
+    condition     = module.microceph.provides.cos_agent == "cos-agent"
+    error_message = "provides should expose cos-agent"
+  }
+}

--- a/terraform/rob-cos-microceph/tests/main.tf
+++ b/terraform/rob-cos-microceph/tests/main.tf
@@ -1,0 +1,26 @@
+data "juju_model" "robcos_model" {
+  name  = "testing"
+  owner = "admin"
+}
+
+data "juju_model" "microceph_model" {
+  name  = "testing-lxd"
+  owner = "admin"
+}
+
+terraform {
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+module "rob_cos_microceph" {
+  source               = "./.."
+  robcos_model_uuid    = data.juju_model.robcos_model.uuid
+  microceph_model_uuid = data.juju_model.microceph_model.uuid
+}

--- a/terraform/rob-cos-microceph/tests/main.tftest.hcl
+++ b/terraform/rob-cos-microceph/tests/main.tftest.hcl
@@ -1,0 +1,75 @@
+run "basic_deploy" {
+  command = apply
+
+  # This corresponds to the apps deployed by rob_cos_microceph.
+  # cos_lite tf module doesn't output app_names.
+  assert {
+    condition     = length(module.rob_cos_microceph.app_names) == 4
+    error_message = "app_names output should not be empty"
+  }
+
+  assert {
+    condition     = contains(keys(module.rob_cos_microceph.app_names), "microceph")
+    error_message = "app_names is missing microceph"
+  }
+
+  assert {
+    condition     = contains(keys(module.rob_cos_microceph.app_names), "blackbox_exporter")
+    error_message = "app_names is missing blackbox_exporter"
+  }
+
+  assert {
+    condition     = contains(keys(module.rob_cos_microceph.app_names), "cos_registration_server")
+    error_message = "app_names is missing cos_registration_server"
+  }
+
+  assert {
+    condition     = contains(keys(module.rob_cos_microceph.app_names), "foxglove_studio")
+    error_message = "app_names is missing foxglove_studio"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.microceph.app_name != ""
+    error_message = "microceph app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.blackbox_exporter.app_name != ""
+    error_message = "blackbox_exporter app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.cos_registration_server.app_name != ""
+    error_message = "cos_registration_server app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.foxglove_studio.app_name != ""
+    error_message = "foxglove_studio app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.traefik.app_name != ""
+    error_message = "traefik app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.catalogue.app_name != ""
+    error_message = "catalogue app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.grafana.app_name != ""
+    error_message = "grafana app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.loki.app_name != ""
+    error_message = "loki app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos_microceph.components.prometheus.app_name != ""
+    error_message = "prometheus app_name should be set"
+  }
+}

--- a/terraform/rob-cos/README.md
+++ b/terraform/rob-cos/README.md
@@ -38,7 +38,7 @@ terraform apply -var="model=<K8S_MODEL_NAME>"
 | Name | Source | Version |
 |------|--------|---------|
 | blackbox\_exporter | git::https://github.com/ubuntu-robotics/blackbox-exporter-k8s-operator//terraform | feat/terraform |
-| cos\_lite | git::https://github.com/canonical/observability-stack//terraform/cos-lite | n/a |
+| cos\_lite | git::https://github.com/canonical/observability-stack//terraform/cos-lite | track/2 |
 | cos\_registration\_server | git::https://github.com/canonical/cos-registration-server-k8s-operator//terraform | n/a |
 | foxglove\_studio | git::https://github.com/ubuntu-robotics/foxglove-k8s-operator//terraform | n/a |
 

--- a/terraform/rob-cos/applications.tf
+++ b/terraform/rob-cos/applications.tf
@@ -19,7 +19,7 @@ module "blackbox_exporter" {
 }
 
 module "cos_lite" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
   channel      = var.cos_lite.channel
   model_uuid   = data.juju_model.model.uuid
   internal_tls = var.cos_lite.internal_tls

--- a/terraform/rob-cos/outputs.tf
+++ b/terraform/rob-cos/outputs.tf
@@ -1,11 +1,10 @@
 output "app_names" {
   value = merge(
     {
-      blackbox_exporter      = module.blackbox_exporter.app_name,
-      cos_registratio_server = module.cos_registration_server.app_name,
-      foxglove_studio        = module.foxglove_studio.app_name,
-      #cos_lite               = module.cos_lite.app_names,
-    }
+      blackbox_exporter       = module.blackbox_exporter.app_name,
+      cos_registration_server = module.cos_registration_server.app_name,
+      foxglove_studio         = module.foxglove_studio.app_name,
+    },
   )
   description = "The names of the deployed applications"
 }

--- a/terraform/rob-cos/tests/main.tf
+++ b/terraform/rob-cos/tests/main.tf
@@ -1,0 +1,20 @@
+data "juju_model" "model" {
+  name  = "testing"
+  owner = "admin"
+}
+
+terraform {
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+module "rob_cos" {
+  model  = data.juju_model.model.name
+  source = "./.."
+}

--- a/terraform/rob-cos/tests/main.tftest.hcl
+++ b/terraform/rob-cos/tests/main.tftest.hcl
@@ -71,6 +71,6 @@ run "basic_deploy" {
   # We do not deploy ssc by default
   assert {
     condition     = contains(keys(module.rob_cos.app_names), "ssc") == false
-    error_message = "cos-lite ssc app_name should be set"
+    error_message = "cos-lite ssc app_name should not be present by default"
   }
 }

--- a/terraform/rob-cos/tests/main.tftest.hcl
+++ b/terraform/rob-cos/tests/main.tftest.hcl
@@ -1,0 +1,76 @@
+run "basic_deploy" {
+  command = apply
+
+  # This corresponds to the apps deployed by rob_cos.
+  # cos_lite tf module doesn't output app_names.
+  assert {
+    condition     = length(module.rob_cos.app_names) == 3
+    error_message = "app_names output should not be empty"
+  }
+
+  assert {
+    condition     = contains(keys(module.rob_cos.app_names), "blackbox_exporter")
+    error_message = "app_names is missing blackbox_exporter"
+  }
+
+  assert {
+    condition     = contains(keys(module.rob_cos.app_names), "cos_registration_server")
+    error_message = "app_names is missing cos_registration_server"
+  }
+
+  assert {
+    condition     = contains(keys(module.rob_cos.app_names), "foxglove_studio")
+    error_message = "app_names is missing foxglove_studio"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.blackbox_exporter.app_name != ""
+    error_message = "blackbox_exporter app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.cos_registration_server.app_name != ""
+    error_message = "cos_registration_server app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.foxglove_studio.app_name != ""
+    error_message = "foxglove_studio app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.catalogue.app_name != ""
+    error_message = "cos-lite catalogue app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.alertmanager.app_name != ""
+    error_message = "cos-lite alertmanager app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.grafana.app_name != ""
+    error_message = "cos-lite grafana app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.loki.app_name != ""
+    error_message = "cos-lite loki app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.prometheus.app_name != ""
+    error_message = "cos-lite prometheus app_name should be set"
+  }
+
+  assert {
+    condition     = module.rob_cos.components.traefik.app_name != ""
+    error_message = "cos-lite traefik app_name should be set"
+  }
+
+  # We do not deploy ssc by default
+  assert {
+    condition     = contains(keys(module.rob_cos.app_names), "ssc") == false
+    error_message = "cos-lite ssc app_name should be set"
+  }
+}

--- a/terraform/rob-cos/variables.tf
+++ b/terraform/rob-cos/variables.tf
@@ -13,12 +13,12 @@ variable "model_owner" {
 
 variable "blackbox_exporter" {
   type = object({
-    app_name           = optional(string, "blackbox-exporter")
-    channel            = optional(string, "1/stable")
-    config             = optional(map(string), {})
-    constraints        = optional(string, "arch=amd64")
-    revision           = optional(number, null)
-    units              = optional(number, 1)
+    app_name    = optional(string, "blackbox-exporter")
+    channel     = optional(string, "1/stable")
+    config      = optional(map(string), {})
+    constraints = optional(string, "arch=amd64")
+    revision    = optional(number, null)
+    units       = optional(number, 1)
   })
   default     = {}
   description = <<-EOT

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,65 @@
+[tox]
+min_version = 4.0
+env_list = py
+
+[testenv]
+description = Run unit tests
+deps =
+    pytest
+    jubilant
+commands =
+    pytest
+
+[testenv:terraform-format]
+description = Format terraform files
+commands =
+    terraform fmt -recursive
+allowlist_externals =
+    terraform
+
+[testenv:terraform-validate]
+description = Validate terraform files
+changedir = {toxinidir}/terraform
+commands =
+    terraform fmt -check -recursive -diff
+    terraform init -backend=false
+    terraform validate
+allowlist_externals =
+    terraform
+
+[testenv:terraform-test-rob-cos]
+description = Test terraform rob-cos module
+changedir = {toxinidir}/terraform/rob-cos/tests
+commands =
+    terraform init
+    terraform test -verbose
+allowlist_externals =
+    terraform
+
+[testenv:terraform-test-rob-cos-microceph]
+description = Test terraform rob-cos-microceph module
+changedir = {toxinidir}/terraform/rob-cos-microceph/tests
+commands =
+    terraform init
+    python -c "import sys; sys.stderr.write('\n' + '='*80 + '\nSKIP: rob-cos-microceph tests\nReason: https://github.com/juju/terraform-provider-juju/issues/473\n' + '='*80 + '\n')"
+    #terraform test -verbose
+allowlist_externals =
+    terraform
+
+[testenv:terraform-test-microceph]
+description = Test terraform microceph module
+changedir = {toxinidir}/terraform/microceph/tests
+commands =
+    terraform init
+    terraform test -verbose
+allowlist_externals =
+    terraform
+
+[testenv:terraform-test]
+description = Test terraform modules
+skip_install = true
+deps =
+commands =
+    tox -e terraform-test-rob-cos,terraform-test-rob-cos-microceph,terraform-test-microceph
+allowlist_externals =
+    tox

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,127 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jubilant"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/0b/275edac8b57b0aac34f84073997660ebf536f97d2fa0d85a2cc3321047b6/jubilant-1.7.0.tar.gz", hash = "sha256:46b7c29a4f3336ab16d77d88418dbf8c9d0746e3f80ef42ee4c2d103eff79650", size = 32455, upload-time = "2026-01-29T02:40:10.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/d5/5b95ae9ab5abf283e33c802d286045abda7d826396ba417d5d3a20201b24/jubilant-1.7.0-py3-none-any.whl", hash = "sha256:1dcd70eb10299a95ae9fab405a3ce5f01a15513776b7f8eb4cf7b02808c93cdf", size = 33396, upload-time = "2026-01-29T02:40:09.222Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rob-cos-overlay"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "jubilant" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jubilant" },
+    { name = "pytest" },
+]


### PR DESCRIPTION
This pull request introduces Terraform testing for the project, updates module references for consistency, and improves the CI workflow to include validation and testing of Terraform modules. The changes add test configurations and assertions for all major Terraform modules, ensure proper dependency management, and fix minor typos and source references.

**CI/CD and Testing Enhancements**
- Replaces the `terraform-lint` job with `terraform-validate` and `terraform-test` jobs in the GitHub Actions workflow, adding full validation and testing of Terraform modules in CI, including setup for Juju, LXD, and related environments.
- Introduces a `tox.ini` to standardize local and CI testing, formatting, and validation for all Terraform modules.

**Terraform Module Test Coverage**
- Adds test configurations and assertions for the `microceph`, `rob-cos`, and `rob-cos-microceph` modules, ensuring key outputs and submodules are correctly deployed and exposed.
- While rob-cos-microceph test is ready and the terraform module works, the test has to be disabled for now due to https://github.com/juju/terraform-provider-juju/issues/473


**Module Reference and Output Corrections**
- Updates `cos_lite` module references to use the `track/2` branch in both code and documentation (since main has breaking changes).
- Fixes a typo in the `app_names` output for the `cos_registration_server` key.