### PR TITLE
fix(microceph): use the new terraform model/model_uuid

### DIFF
--- a/terraform/microceph/README.md
+++ b/terraform/microceph/README.md
@@ -46,7 +46,7 @@ terraform apply -var="model=<MODEL_NAME>"
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| model | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| model | Name of the model to deploy to (must be an LXD model) | `string` | n/a | yes |
 | app\_name | Name to give the deployed application | `string` | `"microceph"` | no |
 | channel | Channel that the charm is deployed from | `string` | `"squid/stable"` | no |
 | config | Map of the charm configuration options | `map(string)` | `{}` | no |

--- a/terraform/microceph/README.md
+++ b/terraform/microceph/README.md
@@ -46,11 +46,12 @@ terraform apply -var="model=<MODEL_NAME>"
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| model\_uuid | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| model | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
 | app\_name | Name to give the deployed application | `string` | `"microceph"` | no |
 | channel | Channel that the charm is deployed from | `string` | `"squid/stable"` | no |
 | config | Map of the charm configuration options | `map(string)` | `{}` | no |
 | constraints | String listing constraints for the application | `string` | `"arch=amd64"` | no |
+| model\_owner | The owner of the model to deploy to | `string` | `"admin"` | no |
 | revision | Revision number of the charm | `number` | `null` | no |
 | units | Unit count/scale | `number` | `1` | no |
 

--- a/terraform/microceph/main.tf
+++ b/terraform/microceph/main.tf
@@ -1,7 +1,8 @@
 # -------------- # Model --------------
 
 data "juju_model" "model" {
-  uuid = var.model_uuid
+  name  = var.model
+  owner = var.model_owner
 }
 
 # -------------- # Application --------------

--- a/terraform/microceph/tests/main.tf
+++ b/terraform/microceph/tests/main.tf
@@ -15,6 +15,6 @@ terraform {
 provider "juju" {}
 
 module "microceph" {
-  model_uuid = data.juju_model.model.uuid
-  source     = "./.."
+  model  = data.juju_model.model.name
+  source = "./.."
 }

--- a/terraform/microceph/variables.tf
+++ b/terraform/microceph/variables.tf
@@ -24,9 +24,16 @@ variable "constraints" {
   default     = "arch=amd64"
 }
 
-variable "model_uuid" {
+variable "model" {
   description = "Reference to an existing model resource or data source for the model to deploy to"
   type        = string
+  nullable    = false
+}
+
+variable "model_owner" {
+  description = "The owner of the model to deploy to"
+  type        = string
+  default     = "admin"
   nullable    = false
 }
 

--- a/terraform/microceph/variables.tf
+++ b/terraform/microceph/variables.tf
@@ -25,7 +25,7 @@ variable "constraints" {
 }
 
 variable "model" {
-  description = "Reference to an existing model resource or data source for the model to deploy to"
+  description = "Name of the model to deploy to (must be an LXD model)"
   type        = string
   nullable    = false
 }

--- a/terraform/rob-cos-microceph/README.md
+++ b/terraform/rob-cos-microceph/README.md
@@ -73,8 +73,8 @@ We can then destroy the deployment as usual with `terraform destroy`.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| microceph\_model\_uuid | UUID of the machine model to deploy MicroCeph to | `string` | n/a | yes |
-| robcos\_model\_uuid | UUID of the K8s model to deploy rob-cos to | `string` | n/a | yes |
+| microceph\_model | Name of the machine model to deploy MicroCeph to | `string` | n/a | yes |
+| robcos\_model | Name of the K8s model to deploy rob-cos to | `string` | n/a | yes |
 | cos\_lite | The cos-lite variables. Please refer to the module for more information. | ```object({ channel = optional(string, "1/stable") use_tls = optional(bool, false) })``` | `{}` | no |
 | microceph | The MicroCeph variables. Please refer to the module for more information. | ```object({ channel = optional(string, "squid/stable") revision = optional(number, null) units = optional(number, 3) })``` | `{}` | no |
 | microceph\_controller | The Juju controller credentials for the controller managing the machine model where MicroCeph is to be deployed | ```object({ addresses = optional(string) username = optional(string) password = optional(string) ca_certificate_path = optional(string) })``` | `{}` | no |

--- a/terraform/rob-cos-microceph/main.tf
+++ b/terraform/rob-cos-microceph/main.tf
@@ -19,12 +19,12 @@ provider "juju" {
 # -------------- # Models --------------
 
 data "juju_model" "robcos_model" {
-  uuid     = var.robcos_model_uuid
+  uuid     = var.robcos_model
   provider = juju.robcos
 }
 
 data "juju_model" "microceph_model" {
-  uuid     = var.microceph_model_uuid
+  uuid     = var.microceph_model
   provider = juju.microceph
 }
 
@@ -43,7 +43,7 @@ module "rob_cos" {
 module "microceph" {
   source     = "../microceph"
   app_name   = "microceph"
-  model_uuid = data.juju_model.microceph_model.uuid
+  model = data.juju_model.microceph_model.name
   channel    = var.microceph.channel
   revision   = var.microceph.revision
   units      = var.microceph.units

--- a/terraform/rob-cos-microceph/main.tf
+++ b/terraform/rob-cos-microceph/main.tf
@@ -41,13 +41,13 @@ module "rob_cos" {
 }
 
 module "microceph" {
-  source     = "../microceph"
-  app_name   = "microceph"
-  model = data.juju_model.microceph_model.name
-  channel    = var.microceph.channel
-  revision   = var.microceph.revision
-  units      = var.microceph.units
-  config     = { "enable-rgw" = "*" }
+  source   = "../microceph"
+  app_name = "microceph"
+  model    = data.juju_model.microceph_model.name
+  channel  = var.microceph.channel
+  revision = var.microceph.revision
+  units    = var.microceph.units
+  config   = { "enable-rgw" = "*" }
 
   providers = {
     juju = juju.microceph

--- a/terraform/rob-cos-microceph/tests/main.tf
+++ b/terraform/rob-cos-microceph/tests/main.tf
@@ -20,7 +20,7 @@ terraform {
 provider "juju" {}
 
 module "rob_cos_microceph" {
-  source               = "./.."
+  source          = "./.."
   robcos_model    = data.juju_model.robcos_model.name
   microceph_model = data.juju_model.microceph_model.name
 }

--- a/terraform/rob-cos-microceph/tests/main.tf
+++ b/terraform/rob-cos-microceph/tests/main.tf
@@ -21,6 +21,6 @@ provider "juju" {}
 
 module "rob_cos_microceph" {
   source               = "./.."
-  robcos_model_uuid    = data.juju_model.robcos_model.uuid
-  microceph_model_uuid = data.juju_model.microceph_model.uuid
+  robcos_model    = data.juju_model.robcos_model.name
+  microceph_model = data.juju_model.microceph_model.name
 }

--- a/terraform/rob-cos-microceph/variables.tf
+++ b/terraform/rob-cos-microceph/variables.tf
@@ -1,11 +1,11 @@
-variable "robcos_model_uuid" {
-  description = "UUID of the K8s model to deploy rob-cos to"
+variable "robcos_model" {
+  description = "Name of the K8s model to deploy rob-cos to"
   type        = string
   nullable    = false
 }
 
-variable "microceph_model_uuid" {
-  description = "UUID of the machine model to deploy MicroCeph to"
+variable "microceph_model" {
+  description = "Name of the machine model to deploy MicroCeph to"
   type        = string
   nullable    = false
 }


### PR DESCRIPTION
The microceph terraform was relying on the hold terraform library and model/model_uuid definition.