### PR TITLE
fix(track/1): freeze cos-lite to the latest working commit

### DIFF
--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -1,0 +1,5 @@
+This `cos-lite` Terraform module is a copy of the [observability-stack cos-lite](https://github.com/canonical/observability-stack/tree/22bdedde6e106774d2c6325aa912572db5c76ae0/terraform/cos-lite), and roughly corresponds to when `track/1` was released.
+
+This module additionally pins the application Terraform sources to the latest commits before the breaking changes.
+
+This is a temporary workaround and is intended to be removed in the future.

--- a/terraform/cos-lite/applications.tf
+++ b/terraform/cos-lite/applications.tf
@@ -1,0 +1,83 @@
+module "alertmanager" {
+  source             = "git::https://github.com/canonical/alertmanager-k8s-operator//terraform?ref=d54ed3e232a6a392d9ae67fc20de1e9ea75c7a52"
+  app_name           = var.alertmanager.app_name
+  channel            = var.channel
+  config             = var.alertmanager.config
+  constraints        = var.alertmanager.constraints
+  model_uuid         = var.model_uuid
+  revision           = var.alertmanager.revision
+  storage_directives = var.alertmanager.storage_directives
+  units              = var.alertmanager.units
+}
+
+module "catalogue" {
+  source             = "git::https://github.com/canonical/catalogue-k8s-operator//terraform?ref=1386d068df1e3dee63e53cb65fce5708eaea8389"
+  app_name           = var.catalogue.app_name
+  channel            = var.channel
+  config             = var.catalogue.config
+  constraints        = var.catalogue.constraints
+  model_uuid         = var.model_uuid
+  revision           = var.catalogue.revision
+  storage_directives = var.catalogue.storage_directives
+  units              = var.catalogue.units
+}
+
+module "grafana" {
+  source             = "git::https://github.com/canonical/grafana-k8s-operator//terraform?ref=97cdd7fc90563a0d3fa5186c57290de0e18a2c43"
+  app_name           = var.grafana.app_name
+  channel            = var.channel
+  config             = var.grafana.config
+  constraints        = var.grafana.constraints
+  model_uuid         = var.model_uuid
+  revision           = var.grafana.revision
+  storage_directives = var.grafana.storage_directives
+  units              = var.grafana.units
+}
+
+module "loki" {
+  source             = "git::https://github.com/canonical/loki-k8s-operator//terraform?ref=c9c288b77cd3057374bb75fc7951da23d7300800"
+  app_name           = var.loki.app_name
+  channel            = var.channel
+  config             = var.loki.config
+  constraints        = var.loki.constraints
+  model_uuid         = var.model_uuid
+  storage_directives = var.loki.storage_directives
+  revision           = var.loki.revision
+  units              = var.loki.units
+}
+
+module "prometheus" {
+  source             = "git::https://github.com/canonical/prometheus-k8s-operator//terraform?ref=f60376ce0ac5c670223c4ba5b8b612b3e16d3770"
+  app_name           = var.prometheus.app_name
+  channel            = var.channel
+  config             = var.prometheus.config
+  constraints        = var.prometheus.constraints
+  model_uuid         = var.model_uuid
+  storage_directives = var.prometheus.storage_directives
+  revision           = var.prometheus.revision
+  units              = var.prometheus.units
+}
+
+module "ssc" {
+  count       = var.internal_tls ? 1 : 0
+  source      = "git::https://github.com/canonical/self-signed-certificates-operator//terraform?ref=64d92fd32b3c77ad9eb0783d4a1bb640b9dcfab5"
+  app_name    = var.ssc.app_name
+  channel     = var.ssc.channel
+  config      = var.ssc.config
+  constraints = var.ssc.constraints
+  model_uuid  = var.model_uuid
+  revision    = var.ssc.revision
+  units       = var.ssc.units
+}
+
+module "traefik" {
+  source             = "git::https://github.com/canonical/traefik-k8s-operator//terraform?ref=685bad8248fd75c7eb540deae7bc9528e444552e"
+  app_name           = var.traefik.app_name
+  channel            = var.traefik.channel
+  config             = var.traefik.config
+  constraints        = var.traefik.constraints
+  model_uuid         = var.model_uuid
+  revision           = var.traefik.revision
+  storage_directives = var.traefik.storage_directives
+  units              = var.traefik.units
+}

--- a/terraform/cos-lite/integrations.tf
+++ b/terraform/cos-lite/integrations.tf
@@ -1,0 +1,413 @@
+# -------------- # Provided by Alertmanager --------------
+
+resource "juju_integration" "alertmanager_grafana_dashboards" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.grafana_dashboard
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.grafana_dashboard
+  }
+}
+
+resource "juju_integration" "alertmanager_prometheus" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.alertmanager
+  }
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.alerting
+  }
+}
+
+resource "juju_integration" "alertmanager_self_monitoring_prometheus" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.metrics_endpoint
+  }
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.self_metrics_endpoint
+  }
+}
+
+resource "juju_integration" "alertmanager_loki" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.loki.app_name
+    endpoint = module.loki.endpoints.alertmanager
+  }
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.alerting
+  }
+}
+
+resource "juju_integration" "grafana_source_alertmanager" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.grafana_source
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.grafana_source
+  }
+}
+
+# -------------- # Provided by Grafana --------------
+
+resource "juju_integration" "grafana_self_monitoring_prometheus" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.metrics_endpoint
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.metrics_endpoint
+  }
+}
+
+# -------------- # Provided by Prometheus --------------
+
+resource "juju_integration" "prometheus_grafana_dashboards_provider" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.grafana_dashboard
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.grafana_dashboard
+  }
+}
+
+resource "juju_integration" "prometheus_grafana_source" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.grafana_source
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.grafana_source
+  }
+}
+
+# -------------- # Provided by Loki --------------
+
+resource "juju_integration" "loki_grafana_dashboards_provider" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.loki.app_name
+    endpoint = module.loki.endpoints.grafana_dashboard
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.grafana_dashboard
+  }
+}
+
+resource "juju_integration" "loki_grafana_source" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.loki.app_name
+    endpoint = module.loki.endpoints.grafana_source
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.grafana_source
+  }
+}
+
+resource "juju_integration" "loki_self_monitoring_prometheus" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.metrics_endpoint
+  }
+
+  application {
+    name     = module.loki.app_name
+    endpoint = module.loki.endpoints.metrics_endpoint
+  }
+}
+
+# -------------- # Provided by Catalogue --------------
+
+resource "juju_integration" "catalogue_alertmanager" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.catalogue.app_name
+    endpoint = module.catalogue.endpoints.catalogue
+  }
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.catalogue
+  }
+}
+
+resource "juju_integration" "catalogue_grafana" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.catalogue.app_name
+    endpoint = module.catalogue.endpoints.catalogue
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.catalogue
+  }
+}
+
+resource "juju_integration" "catalogue_prometheus" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.catalogue.app_name
+    endpoint = module.catalogue.endpoints.catalogue
+  }
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.catalogue
+  }
+}
+
+# -------------- # Provided by Traefik --------------
+
+resource "juju_integration" "alertmanager_ingress" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.ingress
+  }
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.ingress
+  }
+}
+
+resource "juju_integration" "catalogue_ingress" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.ingress
+  }
+
+  application {
+    name     = module.catalogue.app_name
+    endpoint = module.catalogue.endpoints.ingress
+  }
+}
+
+resource "juju_integration" "grafana_ingress" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.traefik_route
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.ingress
+  }
+}
+
+resource "juju_integration" "prometheus_ingress" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.ingress_per_unit
+  }
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.ingress
+  }
+}
+
+resource "juju_integration" "loki_ingress" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.ingress_per_unit
+  }
+
+  application {
+    name     = module.loki.app_name
+    endpoint = module.loki.endpoints.ingress
+  }
+}
+
+resource "juju_integration" "traefik_self_monitoring_prometheus" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.metrics_endpoint
+  }
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.metrics_endpoint
+  }
+}
+
+# -------------- # Provided by Self-Signed-Certificates --------------
+
+resource "juju_integration" "alertmanager_certificates" {
+  count      = var.internal_tls ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "catalogue_certificates" {
+  count      = var.internal_tls ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.catalogue.app_name
+    endpoint = module.catalogue.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "grafana_certificates" {
+  count      = var.internal_tls ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "loki_certificates" {
+  count      = var.internal_tls ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.loki.app_name
+    endpoint = module.loki.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "prometheus_certificates" {
+  count      = var.internal_tls ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "traefik_receive_ca_certificate" {
+  count      = var.internal_tls ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.send-ca-cert
+  }
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.receive_ca_cert
+  }
+}
+
+# -------------- # Provided by an external CA --------------
+
+resource "juju_integration" "external_traefik_certificates" {
+  count      = local.tls_termination ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    offer_url = var.external_certificates_offer_url
+  }
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "external_grafana_ca_cert" {
+  count      = local.tls_termination ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    offer_url = var.external_ca_cert_offer_url
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.receive_ca_cert
+  }
+}

--- a/terraform/cos-lite/offers.tf
+++ b/terraform/cos-lite/offers.tf
@@ -1,0 +1,34 @@
+resource "juju_offer" "alertmanager_karma_dashboard" {
+  name             = "alertmanager-karma-dashboard"
+  model_uuid       = var.model_uuid
+  application_name = module.alertmanager.app_name
+  endpoints        = ["karma-dashboard"]
+}
+
+resource "juju_offer" "grafana_dashboards" {
+  name             = "grafana-dashboards"
+  model_uuid       = var.model_uuid
+  application_name = module.grafana.app_name
+  endpoints        = ["grafana-dashboard"]
+}
+
+resource "juju_offer" "loki_logging" {
+  name             = "loki-logging"
+  model_uuid       = var.model_uuid
+  application_name = module.loki.app_name
+  endpoints        = ["logging"]
+}
+
+resource "juju_offer" "prometheus_receive_remote_write" {
+  name             = "prometheus-receive-remote-write"
+  model_uuid       = var.model_uuid
+  application_name = module.prometheus.app_name
+  endpoints        = ["receive-remote-write"]
+}
+
+resource "juju_offer" "prometheus_metrics_endpoint" {
+  name             = "prometheus-metrics-endpoint"
+  model_uuid       = var.model_uuid
+  application_name = module.prometheus.app_name
+  endpoints        = ["metrics-endpoint"]
+}

--- a/terraform/cos-lite/outputs.tf
+++ b/terraform/cos-lite/outputs.tf
@@ -1,0 +1,27 @@
+# -------------- # Integration offers -------------- #
+
+output "offers" {
+  value = {
+    alertmanager_karma_dashboard    = juju_offer.alertmanager_karma_dashboard
+    grafana_dashboards              = juju_offer.grafana_dashboards
+    loki_logging                    = juju_offer.loki_logging
+    prometheus_receive_remote_write = juju_offer.prometheus_receive_remote_write
+    prometheus_metrics_endpoint     = juju_offer.prometheus_metrics_endpoint
+  }
+  description = "All Juju offers which are exposed by this product module"
+}
+
+# -------------- # Submodules -------------- #
+
+output "components" {
+  value = {
+    alertmanager = module.alertmanager
+    catalogue    = module.catalogue
+    grafana      = module.grafana
+    loki         = module.loki
+    prometheus   = module.prometheus
+    ssc          = module.ssc
+    traefik      = module.traefik
+  }
+  description = "All Terraform charm modules which make up this product module"
+}

--- a/terraform/cos-lite/variables.tf
+++ b/terraform/cos-lite/variables.tf
@@ -1,0 +1,142 @@
+# We use constraints to set AntiAffinity in K8s
+# https://discourse.charmhub.io/t/pod-priority-and-affinity-in-juju-charms/4091/13?u=jose
+
+# FIXME: Passing an empty constraints value to the Juju Terraform provider currently
+# causes the operation to fail due to https://github.com/juju/terraform-provider-juju/issues/344
+# Therefore, we set a default value of "arch=amd64" for all applications.
+
+locals {
+  # https://github.com/juju/terraform-provider-juju/issues/972
+  tls_termination = var.external_certificates_offer_url != null ? true : false
+}
+
+variable "channel" {
+  description = "Channel that the applications are (unless overwritten by external_channels) deployed from"
+  type        = string
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing model resource or data source for the model to deploy to"
+  type        = string
+}
+
+variable "internal_tls" {
+  description = "Specify whether to use TLS or not for internal COS communication. By default, TLS is enabled using self-signed-certificates"
+  type        = bool
+  default     = true
+}
+
+variable "external_certificates_offer_url" {
+  description = "A Juju offer URL (e.g. admin/external-ca.certificates) of a CA providing the 'tls_certificates' integration for Traefik to supply it with server certificates."
+  type        = string
+  default     = null
+
+  validation {
+    condition = (
+      (var.external_certificates_offer_url == null && var.external_ca_cert_offer_url == null) ||
+      (var.external_certificates_offer_url != null && var.external_ca_cert_offer_url != null)
+    )
+    error_message = "external_certificates_offer_url and external_ca_cert_offer_url must be supplied together (either both set or both null)."
+  }
+}
+
+variable "external_ca_cert_offer_url" {
+  description = "A Juju offer URL (e.g. admin/external-ca.send-ca-cert) of a CA providing the 'certificate_transfer' integration for applications to trust ingress via Traefik."
+  type        = string
+  default     = null
+}
+
+# -------------- # Application configurations --------------
+
+variable "alertmanager" {
+  type = object({
+    app_name           = optional(string, "alertmanager")
+    config             = optional(map(string), {})
+    constraints        = optional(string, "arch=amd64")
+    revision           = optional(number, null)
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default     = {}
+  description = "Application configuration for Alertmanager. For more details: https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application"
+}
+
+variable "catalogue" {
+  type = object({
+    app_name           = optional(string, "catalogue")
+    config             = optional(map(string), {})
+    constraints        = optional(string, "arch=amd64")
+    revision           = optional(number, null)
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default     = {}
+  description = "Application configuration for Catalogue. For more details: https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application"
+}
+
+variable "grafana" {
+  type = object({
+    app_name           = optional(string, "grafana")
+    config             = optional(map(string), {})
+    constraints        = optional(string, "arch=amd64")
+    revision           = optional(number, null)
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default     = {}
+  description = "Application configuration for Grafana. For more details: https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application"
+}
+
+variable "loki" {
+  type = object({
+    app_name           = optional(string, "loki")
+    config             = optional(map(string), {})
+    constraints        = optional(string, "arch=amd64")
+    revision           = optional(number, null)
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default     = {}
+  description = "Application configuration for Loki. For more details: https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application"
+}
+
+variable "prometheus" {
+  type = object({
+    app_name           = optional(string, "prometheus")
+    config             = optional(map(string), {})
+    constraints        = optional(string, "arch=amd64")
+    revision           = optional(number, null)
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default     = {}
+  description = "Application configuration for Prometheus. For more details: https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application"
+}
+
+variable "ssc" {
+  type = object({
+    app_name           = optional(string, "ca")
+    channel            = optional(string, "1/stable")
+    config             = optional(map(string), {})
+    constraints        = optional(string, "arch=amd64")
+    revision           = optional(number, null)
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default     = {}
+  description = "Application configuration for self-signed-certificates. For more details: https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application"
+}
+
+variable "traefik" {
+  type = object({
+    app_name           = optional(string, "traefik")
+    channel            = optional(string, "latest/stable")
+    config             = optional(map(string), {})
+    constraints        = optional(string, "arch=amd64")
+    revision           = optional(number, null)
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default     = {}
+  description = "Application configuration for Traefik. For more details: https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application"
+}

--- a/terraform/cos-lite/versions.tf
+++ b/terraform/cos-lite/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/rob-cos/README.md
+++ b/terraform/rob-cos/README.md
@@ -38,7 +38,7 @@ terraform apply -var="model=<K8S_MODEL_NAME>"
 | Name | Source | Version |
 |------|--------|---------|
 | blackbox\_exporter | git::https://github.com/ubuntu-robotics/blackbox-exporter-k8s-operator//terraform | feat/terraform |
-| cos\_lite | git::https://github.com/canonical/observability-stack//terraform/cos-lite | 22bdedde6e106774d2c6325aa912572db5c76ae0 |
+| cos\_lite | ../cos-lite | n/a |
 | cos\_registration\_server | git::https://github.com/canonical/cos-registration-server-k8s-operator//terraform | n/a |
 | foxglove\_studio | git::https://github.com/ubuntu-robotics/foxglove-k8s-operator//terraform | n/a |
 | postgresql | git::https://github.com/canonical/postgresql-k8s-operator//terraform | 986f614b9e437cb69f8ad0d51a1d03d0225033a3 |

--- a/terraform/rob-cos/applications.tf
+++ b/terraform/rob-cos/applications.tf
@@ -19,7 +19,7 @@ module "blackbox_exporter" {
 }
 
 module "cos_lite" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=22bdedde6e106774d2c6325aa912572db5c76ae0"
+  source       = "../cos-lite"
   channel      = var.cos_lite.channel
   model_uuid   = data.juju_model.model.uuid
   internal_tls = var.cos_lite.internal_tls


### PR DESCRIPTION
Recent changes such as: https://github.com/canonical/alertmanager-k8s-operator/commit/8ce6226faca766708cd86f5ee692364ca47d20cd happened on every cos-lite k8s-operator.

This is a breaking change.

This happened because observability-stack didn't have a track/1 branch and never pinned track/1 in the past for the dependent terraforms.

The solution right now was to copy the cos-lite terraform and to pin all the terraform modules.