### PR TITLE
ci(scheduled): schedule a bi-weekly integration testing

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,12 +2,20 @@ name: Integration
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref to checkout
+        required: false
+        type: string
+        default: ""
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.checkout_ref }}
 
     - name: Install dependencies
       run: |
@@ -22,6 +30,7 @@ jobs:
     needs: validate
     uses: ./.github/workflows/juju-lxd-setup.yaml
     with:
+      checkout_ref: ${{ inputs.checkout_ref }}
       command: |
           sudo snap install ros2-cli --channel humble/stable
           tox -e integration

--- a/.github/workflows/juju-lxd-setup.yaml
+++ b/.github/workflows/juju-lxd-setup.yaml
@@ -3,6 +3,10 @@ name: Juju LXD Setup
 on:
   workflow_call:
     inputs:
+      checkout_ref:
+        required: false
+        type: string
+        default: ""
       command:
         required: true
         type: string
@@ -12,6 +16,8 @@ jobs:
     runs-on: self-hosted-linux-amd64-noble-2xlarge
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.checkout_ref }}
       # actions/cache cannot be launched as root
       # and /var/lib/snapd/snaps access needs root
     - name: root suid tar

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,10 +9,21 @@ on:
       - '*.yaml'
     branches:
       - main
+  workflow_call:
+    inputs:
+      branch:
+        description: Branch to run checks against when called as reusable workflow
+        required: true
+        type: string
 
 jobs:
   terraform:
     uses: ./.github/workflows/terraform.yaml
+    with:
+      checkout_ref: ${{ inputs.branch }}
+      run_terraform_docs: ${{ github.event_name == 'pull_request' }}
   integration:
     needs: terraform
     uses: ./.github/workflows/integration.yaml
+    with:
+      checkout_ref: ${{ inputs.branch }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,0 +1,11 @@
+name: Scheduled
+
+on:
+  schedule:
+    - cron: '0 0 */14 * *'
+
+jobs:
+  pull-request-workflow:
+    uses: ./.github/workflows/pull-request.yaml
+    with:
+      branch: main

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -2,7 +2,8 @@ name: Scheduled
 
 on:
   schedule:
-    - cron: '0 0 */14 * *'
+    - cron: '0 0 1 * *'
+    - cron: '0 0 15 * *'
 
 jobs:
   pull-request-workflow:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -2,14 +2,26 @@ name: Terraform
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref to checkout
+        required: false
+        type: string
+        default: ""
+      run_terraform_docs:
+        description: Run terraform-docs generation and push to PR branch
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   terraform-docs:
+    if: ${{ inputs.run_terraform_docs }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ inputs.checkout_ref }}
 
     - name: Render terraform docs and push changes back to PR
       uses: terraform-docs/gh-actions@v1
@@ -23,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.checkout_ref }}
 
     - name: Install dependencies
       run: |
@@ -38,4 +52,5 @@ jobs:
     needs: terraform-validate
     uses: ./.github/workflows/juju-lxd-setup.yaml
     with:
+      checkout_ref: ${{ inputs.checkout_ref }}
       command: tox -e terraform-test


### PR DESCRIPTION
Schedule a bi-weekly integration testing to check for regretion from the outside world.

Added the `checkout_ref` as an input so in the future we will be able to trigger bi-weekly the integration tests from tracks.