### PR TITLE
fix: remove sitepackages for integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ commands =
 [testenv:integration]
 description = Run integration tests
 changedir = {toxinidir}/tests/integration
-sitepackages = true
 deps =
     {[testenv]deps}
 passenv =


### PR DESCRIPTION
Craft-providers has now been migrated to pylxd. Pylxd has a tight dependency to pyopenssl which is incompatible with the system pyopenssl.
I can't remember why we needed this site-package in the first place.